### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ workstations.
 (https://travis-ci.org/Robpol86/jira-context)
 [![Coverage Status](https://img.shields.io/coveralls/Robpol86/jira-context.svg)]
 (https://coveralls.io/r/Robpol86/jira-context)
-[![Latest Version](https://pypip.in/version/jira-context/badge.png)]
+[![Latest Version](https://img.shields.io/pypi/v/jira-context.svg
 (https://pypi.python.org/pypi/jira-context/)
-[![Downloads](https://pypip.in/download/jira-context/badge.png)]
+[![Downloads](https://img.shields.io/pypi/dm/jira-context.svg
 (https://pypi.python.org/pypi/jira-context/)
-[![Download format](https://pypip.in/format/jira-context/badge.png)]
+[![Download format](https://img.shields.io/pypi/format/jira-context.svg
 (https://pypi.python.org/pypi/jira-context/)
-[![License](https://pypip.in/license/jira-context/badge.png)]
+[![License](https://img.shields.io/pypi/l/jira-context.svg
 (https://pypi.python.org/pypi/jira-context/)
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -9,18 +9,12 @@ workstations.
 
 `jira-context` is supported on Python 2.6, 2.7, 3.3, and 3.4.
 
-[![Build Status](https://travis-ci.org/Robpol86/jira-context.svg?branch=master)]
-(https://travis-ci.org/Robpol86/jira-context)
-[![Coverage Status](https://img.shields.io/coveralls/Robpol86/jira-context.svg)]
-(https://coveralls.io/r/Robpol86/jira-context)
-[![Latest Version](https://img.shields.io/pypi/v/jira-context.svg
-(https://pypi.python.org/pypi/jira-context/)
-[![Downloads](https://img.shields.io/pypi/dm/jira-context.svg
-(https://pypi.python.org/pypi/jira-context/)
-[![Download format](https://img.shields.io/pypi/format/jira-context.svg
-(https://pypi.python.org/pypi/jira-context/)
-[![License](https://img.shields.io/pypi/l/jira-context.svg
-(https://pypi.python.org/pypi/jira-context/)
+[![Build Status](https://travis-ci.org/Robpol86/jira-context.svg?branch=master)](https://travis-ci.org/Robpol86/jira-context)
+[![Coverage Status](https://img.shields.io/coveralls/Robpol86/jira-context.svg)](https://coveralls.io/r/Robpol86/jira-context)
+[![Latest Version](https://img.shields.io/pypi/v/jira-context.svg)](https://pypi.python.org/pypi/jira-context/)
+[![Downloads](https://img.shields.io/pypi/dm/jira-context.svg)](https://pypi.python.org/pypi/jira-context/)
+[![Download format](https://img.shields.io/pypi/format/jira-context.svg)](https://pypi.python.org/pypi/jira-context/)
+[![License](https://img.shields.io/pypi/l/jira-context.svg)](https://pypi.python.org/pypi/jira-context/)
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ workstations.
 [![Build Status](https://travis-ci.org/Robpol86/jira-context.svg?branch=master)](https://travis-ci.org/Robpol86/jira-context)
 [![Coverage Status](https://img.shields.io/coveralls/Robpol86/jira-context.svg)](https://coveralls.io/r/Robpol86/jira-context)
 [![Latest Version](https://img.shields.io/pypi/v/jira-context.svg)](https://pypi.python.org/pypi/jira-context/)
-[![Downloads](https://img.shields.io/pypi/dm/jira-context.svg)](https://pypi.python.org/pypi/jira-context/)
 [![Download format](https://img.shields.io/pypi/format/jira-context.svg)](https://pypi.python.org/pypi/jira-context/)
 [![License](https://img.shields.io/pypi/l/jira-context.svg)](https://pypi.python.org/pypi/jira-context/)
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20jira-context))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `jira-context`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.